### PR TITLE
Fix bug in on-select that returns result object inside another object.

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -203,10 +203,10 @@
                                         $scope.$apply(function () {
                                             if ($attrs.select) {
                                                 console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
-                                                $scope.select({ selectEventRetParams: selectEventRetParams });
+                                                $scope.select(selectEventRetParams);
                                             }
                                             else {
-                                                $scope.onSelect({ selectEventRetParams: selectEventRetParams });
+                                                $scope.onSelect(selectEventRetParams);
                                             }
                                         });
                                     });


### PR DESCRIPTION
I merged someone else's code and it broke some stuff.  I hadn't tested it so it's my bad.  This should fix it, I'd love it if anyone else could test it.

The test case is adding an on-select callback.  If the parameter is named `selectedItem` it should return one item (the first in the list if there is a range).  If named `selectedItems` it should return an array of selected items.

```HTML
<!-- one item -->
<div google-chart chart="myChart" on-select="selected(selectedItem)"></div>
<!-- many items -->
<div google-chart chart="myChart" on-select="selected(selectedItems)"</div>
```

I've tested this in both cases on my own project in Chrome version 39.0.2171.95 with Angular v1.2.28