### PR TITLE
Refactor directives

### DIFF
--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -34,6 +34,7 @@
                 return (protocol ? protocol : '') + url;
             };
         })
+
         .factory('googleChartApiPromise', ['$rootScope', '$q', 'googleChartApiConfig', 'googleJsapiUrl', function ($rootScope, $q, apiConfig, googleJsapiUrl) {
             var apiReady = $q.defer();
             var onLoad = function () {
@@ -76,6 +77,7 @@
 
             return apiReady.promise;
         }])
+
         .directive('googleChart', ['$timeout', '$window', '$rootScope', 'googleChartApiPromise', function ($timeout, $window, $rootScope, googleChartApiPromise) {
             return {
                 restrict: 'A',
@@ -85,34 +87,9 @@
                         or type change. All other values intentionally disregarded to avoid double
                         calls to the draw function. Please avoid making changes to these objects
                         directly from this directive.*/
-                        var self = this;
-                    $scope.$watch('{ customFormatters: '+ $attrs.chart +'.customFormatters, ' +
-                    'data: ' + $attrs.chart + '.data, ' +
-                    'formatters: ' + $attrs.chart +'.formatters, ' +
-                    'options: ' + $attrs.chart +'.options, ' +
-                    'type: ' + $attrs.chart +'.type, ' +
-                    'view: ' + $attrs.chart +'.view }', function () {
-                    self.chart = $scope.$eval($attrs.chart);
-                        drawAsync();
-                    }, true); // true is for deep object equality checking
-
-                    // Redraw the chart if the window is resized
-                    var resizeHandler = $rootScope.$on('resizeMsg', function () {
-                        $timeout(function () {
-                            // Not always defined yet in IE so check
-                            if (self.chartWrapper) {
-                                drawAsync();
-                            }
-                        });
-                    });
-
-                    //Cleanup resize handler.
-                    $scope.$on('$destroy', function () {
-                        resizeHandler();
-                    });
-
-                    // Keeps old formatter configuration to compare against
-                    var oldChartFormatters = {};
+                    var self = this;
+                    var oldChartFormatters = {}, resizeHandler;
+                    init();
 
                     function applyFormat(formatType, formatClass, dataTable) {
                         var i;
@@ -128,10 +105,11 @@
                                         for (i = 0; i < self.chart.formatters[formatType][cIdx].formats.length; i++) {
                                             var data = self.chart.formatters[formatType][cIdx].formats[i];
 
-                                            if (typeof (data.fromBgColor) !== 'undefined' && typeof (data.toBgColor) !== 'undefined')
+                                            if (typeof (data.fromBgColor) !== 'undefined' && typeof (data.toBgColor) !== 'undefined') {
                                                 colorFormat.addGradientRange(data.from, data.to, data.color, data.fromBgColor, data.toBgColor);
-                                            else
+                                            } else {
                                                 colorFormat.addRange(data.from, data.to, data.color, data.bgcolor);
+                                            }
                                         }
 
                                         self.formatters[formatType].push(colorFormat);
@@ -149,88 +127,27 @@
 
                             //apply formats to dataTable
                             for (i = 0; i < self.formatters[formatType].length; i++) {
-                                if (self.chart.formatters[formatType][i].columnNum < dataTable.getNumberOfColumns())
+                                if (self.chart.formatters[formatType][i].columnNum < dataTable.getNumberOfColumns()) {
                                     self.formatters[formatType][i].format(dataTable, self.chart.formatters[formatType][i].columnNum);
+                                }
                             }
 
 
                             //Many formatters require HTML tags to display special formatting
-                            if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color')
+                            if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color') {
                                 self.chart.options.allowHtml = true;
+                            }
                         }
+                    }
+
+                    function cleanup(){
+                        resizeHandler();
                     }
 
                     function draw() {
                         if (!draw.triggered && (self.chart !== undefined)) {
                             draw.triggered = true;
-                            $timeout(function () {
-
-                                if (typeof (self.chartWrapper) === 'undefined') {
-                                    var chartWrapperArgs = {
-                                        chartType: self.chart.type,
-                                        dataTable: self.chart.data,
-                                        view: self.chart.view,
-                                        options: self.chart.options,
-                                        containerId: $element[0]
-                                    };
-
-                                    self.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
-                                    google.visualization.events.addListener(self.chartWrapper, 'ready', function () {
-                                        self.chart.displayed = true;
-                                        $scope.$apply(function () {
-                                            $scope.$eval($attrs.onReady, { chartWrapper: self.chartWrapper });
-                                        });
-                                    });
-                                    google.visualization.events.addListener(self.chartWrapper, 'error', function (err) {
-                                        console.log("Chart not displayed due to error: " + err.message + ". Full error object follows.");
-                                        console.log(err);
-                                    });
-                                    google.visualization.events.addListener(self.chartWrapper, 'select', function () {
-                                        var selectEventRetParams = { selectedItems: self.chartWrapper.getChart().getSelection() };
-                                        // This is for backwards compatibility for people using 'selectedItem' that only wanted the first selection.
-                                        selectEventRetParams.selectedItem = selectEventRetParams.selectedItems[0];
-                                        $scope.$apply(function () {
-                                            if ($attrs.select) {
-                                                console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
-                                                $scope.$eval($attrs.select, selectEventRetParams);
-                                            }
-                                            else {
-                                                $scope.$eval($attrs.onSelect, selectEventRetParams);
-                                            }
-                                        });
-                                    });
-                                }
-                                else {
-                                    self.chartWrapper.setChartType(self.chart.type);
-                                    self.chartWrapper.setDataTable(self.chart.data);
-                                    self.chartWrapper.setView(self.chart.view);
-                                    self.chartWrapper.setOptions(self.chart.options);
-                                }
-
-                                if (typeof (self.formatters) === 'undefined')
-                                    self.formatters = {};
-
-                                if (typeof (self.chart.formatters) !== 'undefined') {
-                                    applyFormat("number", google.visualization.NumberFormat, self.chartWrapper.getDataTable());
-                                    applyFormat("arrow", google.visualization.ArrowFormat, self.chartWrapper.getDataTable());
-                                    applyFormat("date", google.visualization.DateFormat, self.chartWrapper.getDataTable());
-                                    applyFormat("bar", google.visualization.BarFormat, self.chartWrapper.getDataTable());
-                                    applyFormat("color", google.visualization.ColorFormat, self.chartWrapper.getDataTable());
-                                }
-
-                                var customFormatters = self.chart.customFormatters;
-                                if (typeof (customFormatters) !== 'undefined') {
-                                    for (var name in customFormatters) {
-                                        applyFormat(name, customFormatters[name], self.chartWrapper.getDataTable());
-                                    }
-                                }
-
-                                $timeout(function () {
-                                    $scope.$eval($attrs.beforeDraw, { chartWrapper: $scope.chartWrapper });
-                                    self.chartWrapper.draw();
-                                    draw.triggered = false;
-                                });
-                            }, 0, true);
+                            $timeout(setupAndDraw, 0, true);
                         } else if (self.chart !== undefined) {
                             $timeout.cancel(draw.recallTimeout);
                             draw.recallTimeout = $timeout(draw, 10);
@@ -241,6 +158,106 @@
                         googleChartApiPromise.then(function () {
                             draw();
                         });
+                    }
+
+                    function drawChartWrapper(){
+                        $scope.$eval($attrs.beforeDraw, { chartWrapper: $scope.chartWrapper });
+                        self.chartWrapper.draw();
+                        draw.triggered = false;
+                    }
+
+                    function handleError(err) {
+                        console.log("Chart not displayed due to error: " + err.message + ". Full error object follows.");
+                        console.log(err);
+                    }
+
+                    function handleReady() {
+                        self.chart.displayed = true;
+                        $scope.$apply(function () {
+                            $scope.$eval($attrs.onReady, { chartWrapper: self.chartWrapper });
+                        });
+                    }
+
+                    function handleSelect() {
+                        var selectEventRetParams = { selectedItems: self.chartWrapper.getChart().getSelection() };
+                        // This is for backwards compatibility for people using 'selectedItem' that only wanted the first selection.
+                        selectEventRetParams.selectedItem = selectEventRetParams.selectedItems[0];
+                        $scope.$apply(function () {
+                            if ($attrs.select) {
+                                console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
+                                $scope.$eval($attrs.select, selectEventRetParams);
+                            }
+                            else {
+                                $scope.$eval($attrs.onSelect, selectEventRetParams);
+                            }
+                        });
+                    }
+
+                    function init(){
+                        $scope.$watch('{ customFormatters: '+ $attrs.chart +'.customFormatters, ' +
+                        'data: ' + $attrs.chart + '.data, ' +
+                        'formatters: ' + $attrs.chart +'.formatters, ' +
+                        'options: ' + $attrs.chart +'.options, ' +
+                        'type: ' + $attrs.chart +'.type, ' +
+                        'view: ' + $attrs.chart +'.view }', function () {
+                            self.chart = $scope.$eval($attrs.chart);
+                            drawAsync();
+                        }, true); // true is for deep object equality checking
+
+                        // Redraw the chart if the window is resized
+                        resizeHandler = $rootScope.$on('resizeMsg', function () {
+                            $timeout(function () {
+                                // Not always defined yet in IE so check
+                                if (self.chartWrapper) {
+                                    drawAsync();
+                                }
+                            });
+                        });
+
+                        //Cleanup resize handler.
+                        $scope.$on('$destroy', cleanup());
+                    }
+
+                    function setupAndDraw(){
+                        if (typeof (self.chartWrapper) === 'undefined') {
+                            var chartWrapperArgs = {
+                                chartType: self.chart.type,
+                                dataTable: self.chart.data,
+                                view: self.chart.view,
+                                options: self.chart.options,
+                                containerId: $element[0]
+                            };
+
+                            self.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
+                            google.visualization.events.addListener(self.chartWrapper, 'ready', handleReady);
+                            google.visualization.events.addListener(self.chartWrapper, 'error', handleError);
+                            google.visualization.events.addListener(self.chartWrapper, 'select', handleSelect);
+                        } else {
+                            self.chartWrapper.setChartType(self.chart.type);
+                            self.chartWrapper.setDataTable(self.chart.data);
+                            self.chartWrapper.setView(self.chart.view);
+                            self.chartWrapper.setOptions(self.chart.options);
+                        }
+
+                        if (typeof (self.formatters) === 'undefined')
+                            self.formatters = {};
+
+                            if (typeof (self.chart.formatters) !== 'undefined') {
+                                applyFormat("number", google.visualization.NumberFormat, self.chartWrapper.getDataTable());
+                                applyFormat("arrow", google.visualization.ArrowFormat, self.chartWrapper.getDataTable());
+                                applyFormat("date", google.visualization.DateFormat, self.chartWrapper.getDataTable());
+                                applyFormat("bar", google.visualization.BarFormat, self.chartWrapper.getDataTable());
+                                applyFormat("color", google.visualization.ColorFormat, self.chartWrapper.getDataTable());
+                            }
+
+                            var customFormatters = self.chart.customFormatters;
+                            if (typeof (customFormatters) !== 'undefined') {
+                                for (var name in customFormatters) {
+                                    applyFormat(name, customFormatters[name], self.chartWrapper.getDataTable());
+                                }
+                            }
+
+                            $timeout(drawChartWrapper);
                     }
                 }
             };

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -194,15 +194,7 @@
                     or type change. All other values intentionally disregarded to avoid double
                     calls to the draw function. Please avoid making changes to these objects
                     directly from this directive.*/
-                    $scope.$watch('{ customFormatters: '+ $attrs.chart +'.customFormatters, ' +
-                    'data: ' + $attrs.chart + '.data, ' +
-                    'formatters: ' + $attrs.chart +'.formatters, ' +
-                    'options: ' + $attrs.chart +'.options, ' +
-                    'type: ' + $attrs.chart +'.type, ' +
-                    'view: ' + $attrs.chart +'.view }', function () {
-                        self.chart = $scope.$eval($attrs.chart);
-                        drawAsync();
-                    }, true); // true is for deep object equality checking
+                    $scope.$watch(watchValue, watchHandler, true); // true is for deep object equality checking
 
                     // Redraw the chart if the window is resized
                     resizeHandler = $rootScope.$on('resizeMsg', function () {
@@ -258,6 +250,25 @@
                         }
 
                         $timeout(drawChartWrapper);
+                    }
+
+                    function watchHandler(){
+                        self.chart = $scope.$eval($attrs.chart);
+                        drawAsync();
+                    }
+
+                    function watchValue(){
+                        var chartObject = $scope.$eval($attrs.chart);
+                        if (angular.isDefined(chartObject) && angular.isObject(chartObject)){
+                            return {
+                                customFormatters: chartObject.customFormatters,
+                                data: chartObject.data,
+                                formatters: chartObject.formatters,
+                                options: chartObject.options,
+                                type: chartObject.type,
+                                view: chartObject.view
+                            };
+                        }
                     }
             }
 

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -345,7 +345,7 @@
 
         .directive('onSelect', function(){
             return {
-                retrist: 'A',
+                restrict: 'A',
                 scope: false,
                 require: 'googleChart',
                 link: function(scope, element, attrs, googleChartController){

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -336,7 +336,9 @@
                 link: function(scope, element, attrs, googleChartController){
                     callback.$inject=['chartWrapper'];
                     function callback(chartWrapper){
-                        scope.$eval(attrs.onReady, {chartWrapper: chartWrapper});
+                        scope.$apply(function (){
+                            scope.$eval(attrs.onReady, {chartWrapper: chartWrapper});
+                        });
                     }
                     googleChartController.registerWrapperListener('ready', callback, this);
                 }

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -86,7 +86,7 @@
                     onSelect: '&',
                     select: '&'
                 },
-                link: function ($scope, $elm, $attrs) {
+                controller: function ($scope, $element, $attrs) {
                     /* Watches, to refresh the chart when its data, formatters, options, view,
                         or type change. All other values intentionally disregarded to avoid double
                         calls to the draw function. Please avoid making changes to these objects
@@ -182,7 +182,7 @@
                                         dataTable: $scope.chart.data,
                                         view: $scope.chart.view,
                                         options: $scope.chart.options,
-                                        containerId: $elm[0]
+                                        containerId: $element[0]
                                     };
 
                                     $scope.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -86,7 +86,7 @@
                 var self = this;
                 var oldChartFormatters = {}, resizeHandler, wrapperListeners = {};
                 self.registerWrapperListener = registerWrapperListener;
-                window.myDebug = wrapperListeners;
+                
                 init();
 
                 function applyFormat(formatType, formatClass, dataTable) {

--- a/ng-google-chart.js
+++ b/ng-google-chart.js
@@ -79,187 +79,192 @@
         }])
 
         .directive('googleChart', ['$timeout', '$window', '$rootScope', 'googleChartApiPromise', function ($timeout, $window, $rootScope, googleChartApiPromise) {
+
+            GoogleChartController.$inject = ['$scope', '$element', '$attrs'];
+            
+            function GoogleChartController($scope, $element, $attrs){
+                var self = this;
+                var oldChartFormatters = {}, resizeHandler;
+                init();
+
+                function applyFormat(formatType, formatClass, dataTable) {
+                    var i;
+                    if (typeof (self.chart.formatters[formatType]) !== 'undefined') {
+                        if (!angular.equals(self.chart.formatters[formatType], oldChartFormatters[formatType])) {
+                            oldChartFormatters[formatType] = self.chart.formatters[formatType];
+                            self.formatters[formatType] = [];
+
+                            if (formatType === 'color') {
+                                for (var cIdx = 0; cIdx < self.chart.formatters[formatType].length; cIdx++) {
+                                    var colorFormat = new formatClass();
+
+                                    for (i = 0; i < self.chart.formatters[formatType][cIdx].formats.length; i++) {
+                                        var data = self.chart.formatters[formatType][cIdx].formats[i];
+
+                                        if (typeof (data.fromBgColor) !== 'undefined' && typeof (data.toBgColor) !== 'undefined') {
+                                            colorFormat.addGradientRange(data.from, data.to, data.color, data.fromBgColor, data.toBgColor);
+                                        } else {
+                                            colorFormat.addRange(data.from, data.to, data.color, data.bgcolor);
+                                        }
+                                    }
+
+                                    self.formatters[formatType].push(colorFormat);
+                                }
+                            } else {
+
+                                for (i = 0; i < self.chart.formatters[formatType].length; i++) {
+                                    self.formatters[formatType].push(new formatClass(
+                                        self.chart.formatters[formatType][i])
+                                    );
+                                }
+                            }
+                        }
+
+
+                        //apply formats to dataTable
+                        for (i = 0; i < self.formatters[formatType].length; i++) {
+                            if (self.chart.formatters[formatType][i].columnNum < dataTable.getNumberOfColumns()) {
+                                self.formatters[formatType][i].format(dataTable, self.chart.formatters[formatType][i].columnNum);
+                            }
+                        }
+
+
+                        //Many formatters require HTML tags to display special formatting
+                        if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color') {
+                            self.chart.options.allowHtml = true;
+                        }
+                    }
+                }
+
+                function cleanup(){
+                    resizeHandler();
+                }
+
+                function draw() {
+                    if (!draw.triggered && (self.chart !== undefined)) {
+                        draw.triggered = true;
+                        $timeout(setupAndDraw, 0, true);
+                    } else if (self.chart !== undefined) {
+                        $timeout.cancel(draw.recallTimeout);
+                        draw.recallTimeout = $timeout(draw, 10);
+                    }
+                }
+
+                function drawAsync() {
+                    googleChartApiPromise.then(function () {
+                        draw();
+                    });
+                }
+
+                function drawChartWrapper(){
+                    $scope.$eval($attrs.beforeDraw, { chartWrapper: $scope.chartWrapper });
+                    self.chartWrapper.draw();
+                    draw.triggered = false;
+                }
+
+                function handleError(err) {
+                    console.log("Chart not displayed due to error: " + err.message + ". Full error object follows.");
+                    console.log(err);
+                }
+
+                function handleReady() {
+                    self.chart.displayed = true;
+                    $scope.$apply(function () {
+                        $scope.$eval($attrs.onReady, { chartWrapper: self.chartWrapper });
+                    });
+                }
+
+                function handleSelect() {
+                    var selectEventRetParams = { selectedItems: self.chartWrapper.getChart().getSelection() };
+                    // This is for backwards compatibility for people using 'selectedItem' that only wanted the first selection.
+                    selectEventRetParams.selectedItem = selectEventRetParams.selectedItems[0];
+                    $scope.$apply(function () {
+                        if ($attrs.select) {
+                            console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
+                            $scope.$eval($attrs.select, selectEventRetParams);
+                        }
+                        else {
+                            $scope.$eval($attrs.onSelect, selectEventRetParams);
+                        }
+                    });
+                }
+
+                function init(){
+                    /* Watches, to refresh the chart when its data, formatters, options, view,
+                    or type change. All other values intentionally disregarded to avoid double
+                    calls to the draw function. Please avoid making changes to these objects
+                    directly from this directive.*/
+                    $scope.$watch('{ customFormatters: '+ $attrs.chart +'.customFormatters, ' +
+                    'data: ' + $attrs.chart + '.data, ' +
+                    'formatters: ' + $attrs.chart +'.formatters, ' +
+                    'options: ' + $attrs.chart +'.options, ' +
+                    'type: ' + $attrs.chart +'.type, ' +
+                    'view: ' + $attrs.chart +'.view }', function () {
+                        self.chart = $scope.$eval($attrs.chart);
+                        drawAsync();
+                    }, true); // true is for deep object equality checking
+
+                    // Redraw the chart if the window is resized
+                    resizeHandler = $rootScope.$on('resizeMsg', function () {
+                        $timeout(function () {
+                            // Not always defined yet in IE so check
+                            if (self.chartWrapper) {
+                                drawAsync();
+                            }
+                        });
+                    });
+
+                    //Cleanup resize handler.
+                    $scope.$on('$destroy', cleanup());
+                }
+
+                function setupAndDraw(){
+                    if (typeof (self.chartWrapper) === 'undefined') {
+                        var chartWrapperArgs = {
+                            chartType: self.chart.type,
+                            dataTable: self.chart.data,
+                            view: self.chart.view,
+                            options: self.chart.options,
+                            containerId: $element[0]
+                        };
+
+                        self.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
+                        google.visualization.events.addListener(self.chartWrapper, 'ready', handleReady);
+                        google.visualization.events.addListener(self.chartWrapper, 'error', handleError);
+                        google.visualization.events.addListener(self.chartWrapper, 'select', handleSelect);
+                    } else {
+                        self.chartWrapper.setChartType(self.chart.type);
+                        self.chartWrapper.setDataTable(self.chart.data);
+                        self.chartWrapper.setView(self.chart.view);
+                        self.chartWrapper.setOptions(self.chart.options);
+                    }
+
+                    if (typeof (self.formatters) === 'undefined')
+                        self.formatters = {};
+
+                        if (typeof (self.chart.formatters) !== 'undefined') {
+                            applyFormat("number", google.visualization.NumberFormat, self.chartWrapper.getDataTable());
+                            applyFormat("arrow", google.visualization.ArrowFormat, self.chartWrapper.getDataTable());
+                            applyFormat("date", google.visualization.DateFormat, self.chartWrapper.getDataTable());
+                            applyFormat("bar", google.visualization.BarFormat, self.chartWrapper.getDataTable());
+                            applyFormat("color", google.visualization.ColorFormat, self.chartWrapper.getDataTable());
+                        }
+
+                        var customFormatters = self.chart.customFormatters;
+                        if (typeof (customFormatters) !== 'undefined') {
+                            for (var name in customFormatters) {
+                                applyFormat(name, customFormatters[name], self.chartWrapper.getDataTable());
+                            }
+                        }
+
+                        $timeout(drawChartWrapper);
+                    }
+            }
+
             return {
                 restrict: 'A',
                 scope: false,
-                controller: function ($scope, $element, $attrs) {
-                    /* Watches, to refresh the chart when its data, formatters, options, view,
-                        or type change. All other values intentionally disregarded to avoid double
-                        calls to the draw function. Please avoid making changes to these objects
-                        directly from this directive.*/
-                    var self = this;
-                    var oldChartFormatters = {}, resizeHandler;
-                    init();
-
-                    function applyFormat(formatType, formatClass, dataTable) {
-                        var i;
-                        if (typeof (self.chart.formatters[formatType]) !== 'undefined') {
-                            if (!angular.equals(self.chart.formatters[formatType], oldChartFormatters[formatType])) {
-                                oldChartFormatters[formatType] = self.chart.formatters[formatType];
-                                self.formatters[formatType] = [];
-
-                                if (formatType === 'color') {
-                                    for (var cIdx = 0; cIdx < self.chart.formatters[formatType].length; cIdx++) {
-                                        var colorFormat = new formatClass();
-
-                                        for (i = 0; i < self.chart.formatters[formatType][cIdx].formats.length; i++) {
-                                            var data = self.chart.formatters[formatType][cIdx].formats[i];
-
-                                            if (typeof (data.fromBgColor) !== 'undefined' && typeof (data.toBgColor) !== 'undefined') {
-                                                colorFormat.addGradientRange(data.from, data.to, data.color, data.fromBgColor, data.toBgColor);
-                                            } else {
-                                                colorFormat.addRange(data.from, data.to, data.color, data.bgcolor);
-                                            }
-                                        }
-
-                                        self.formatters[formatType].push(colorFormat);
-                                    }
-                                } else {
-
-                                    for (i = 0; i < self.chart.formatters[formatType].length; i++) {
-                                        self.formatters[formatType].push(new formatClass(
-                                            self.chart.formatters[formatType][i])
-                                        );
-                                    }
-                                }
-                            }
-
-
-                            //apply formats to dataTable
-                            for (i = 0; i < self.formatters[formatType].length; i++) {
-                                if (self.chart.formatters[formatType][i].columnNum < dataTable.getNumberOfColumns()) {
-                                    self.formatters[formatType][i].format(dataTable, self.chart.formatters[formatType][i].columnNum);
-                                }
-                            }
-
-
-                            //Many formatters require HTML tags to display special formatting
-                            if (formatType === 'arrow' || formatType === 'bar' || formatType === 'color') {
-                                self.chart.options.allowHtml = true;
-                            }
-                        }
-                    }
-
-                    function cleanup(){
-                        resizeHandler();
-                    }
-
-                    function draw() {
-                        if (!draw.triggered && (self.chart !== undefined)) {
-                            draw.triggered = true;
-                            $timeout(setupAndDraw, 0, true);
-                        } else if (self.chart !== undefined) {
-                            $timeout.cancel(draw.recallTimeout);
-                            draw.recallTimeout = $timeout(draw, 10);
-                        }
-                    }
-
-                    function drawAsync() {
-                        googleChartApiPromise.then(function () {
-                            draw();
-                        });
-                    }
-
-                    function drawChartWrapper(){
-                        $scope.$eval($attrs.beforeDraw, { chartWrapper: $scope.chartWrapper });
-                        self.chartWrapper.draw();
-                        draw.triggered = false;
-                    }
-
-                    function handleError(err) {
-                        console.log("Chart not displayed due to error: " + err.message + ". Full error object follows.");
-                        console.log(err);
-                    }
-
-                    function handleReady() {
-                        self.chart.displayed = true;
-                        $scope.$apply(function () {
-                            $scope.$eval($attrs.onReady, { chartWrapper: self.chartWrapper });
-                        });
-                    }
-
-                    function handleSelect() {
-                        var selectEventRetParams = { selectedItems: self.chartWrapper.getChart().getSelection() };
-                        // This is for backwards compatibility for people using 'selectedItem' that only wanted the first selection.
-                        selectEventRetParams.selectedItem = selectEventRetParams.selectedItems[0];
-                        $scope.$apply(function () {
-                            if ($attrs.select) {
-                                console.log('Angular-Google-Chart: The \'select\' attribute is deprecated and will be removed in a future release.  Please use \'onSelect\'.');
-                                $scope.$eval($attrs.select, selectEventRetParams);
-                            }
-                            else {
-                                $scope.$eval($attrs.onSelect, selectEventRetParams);
-                            }
-                        });
-                    }
-
-                    function init(){
-                        $scope.$watch('{ customFormatters: '+ $attrs.chart +'.customFormatters, ' +
-                        'data: ' + $attrs.chart + '.data, ' +
-                        'formatters: ' + $attrs.chart +'.formatters, ' +
-                        'options: ' + $attrs.chart +'.options, ' +
-                        'type: ' + $attrs.chart +'.type, ' +
-                        'view: ' + $attrs.chart +'.view }', function () {
-                            self.chart = $scope.$eval($attrs.chart);
-                            drawAsync();
-                        }, true); // true is for deep object equality checking
-
-                        // Redraw the chart if the window is resized
-                        resizeHandler = $rootScope.$on('resizeMsg', function () {
-                            $timeout(function () {
-                                // Not always defined yet in IE so check
-                                if (self.chartWrapper) {
-                                    drawAsync();
-                                }
-                            });
-                        });
-
-                        //Cleanup resize handler.
-                        $scope.$on('$destroy', cleanup());
-                    }
-
-                    function setupAndDraw(){
-                        if (typeof (self.chartWrapper) === 'undefined') {
-                            var chartWrapperArgs = {
-                                chartType: self.chart.type,
-                                dataTable: self.chart.data,
-                                view: self.chart.view,
-                                options: self.chart.options,
-                                containerId: $element[0]
-                            };
-
-                            self.chartWrapper = new google.visualization.ChartWrapper(chartWrapperArgs);
-                            google.visualization.events.addListener(self.chartWrapper, 'ready', handleReady);
-                            google.visualization.events.addListener(self.chartWrapper, 'error', handleError);
-                            google.visualization.events.addListener(self.chartWrapper, 'select', handleSelect);
-                        } else {
-                            self.chartWrapper.setChartType(self.chart.type);
-                            self.chartWrapper.setDataTable(self.chart.data);
-                            self.chartWrapper.setView(self.chart.view);
-                            self.chartWrapper.setOptions(self.chart.options);
-                        }
-
-                        if (typeof (self.formatters) === 'undefined')
-                            self.formatters = {};
-
-                            if (typeof (self.chart.formatters) !== 'undefined') {
-                                applyFormat("number", google.visualization.NumberFormat, self.chartWrapper.getDataTable());
-                                applyFormat("arrow", google.visualization.ArrowFormat, self.chartWrapper.getDataTable());
-                                applyFormat("date", google.visualization.DateFormat, self.chartWrapper.getDataTable());
-                                applyFormat("bar", google.visualization.BarFormat, self.chartWrapper.getDataTable());
-                                applyFormat("color", google.visualization.ColorFormat, self.chartWrapper.getDataTable());
-                            }
-
-                            var customFormatters = self.chart.customFormatters;
-                            if (typeof (customFormatters) !== 'undefined') {
-                                for (var name in customFormatters) {
-                                    applyFormat(name, customFormatters[name], self.chartWrapper.getDataTable());
-                                }
-                            }
-
-                            $timeout(drawChartWrapper);
-                    }
-                }
+                controller: GoogleChartController
             };
         }])
 


### PR DESCRIPTION
This pull request makes no functional changes (unless they're a bug).

It does 3 things:
 - Replace the `link` function with a controller.
 - Strip out isolate scope.
 - Some pretty big code cleanup.

### Controller instead of Link
Using a controller instead of the link function allows us to expose an API for further directive writing.  My intent is to use this to handle registration of chart event listeners in a flexible way, without cluttering the main directive too much.

### Remove Isolate Scope
While I'm not 100% certain on the implications down the road, I noticed when I tried to flesh out a directive definition for a separate directive that registers an event handler that an element can only have one scope, and to bind to a function without isolate scope for new dependent directives, you'd need `$scope.$eval()`.  In all honesty, I did not test the behavior of this architecture without removing the isolate scope, but it was enough work figuring out how this all worked without spending 3 days testing things that I couldn't find any info on.

### Code Cleanup
In my own work I try to abide by the guidelines in the community written [AngularJS Style Guide](https://github.com/johnpapa/angular-styleguide).  This directive was getting really hard to work on, so I've gone ahead and gave names to a lot of the anonymous functions as per [Y024](https://github.com/johnpapa/angular-styleguide#style-y024).  I know this style guide was never really established as a standard for this project, but while editing the code I felt a need for this rule.  There were just too many nested callback functions.

### Feedback?
With my plans to use the controller for the `googleChart` directive in mind, any issues with this change?  I've only tested it by running the samples, but I'll plug it into my work project before merging to make sure some of the more advanced features I was already using didn't break.  The road I'm going down with this may lead to some breaking changes soon, but everything I'm planning to do appears to work with angular 1.2.9 up to 1.4.x, so it shouldn't force any older apps to stop pulling in these changes.